### PR TITLE
refactor: centralize constants and add icons

### DIFF
--- a/ui/business_new.py
+++ b/ui/business_new.py
@@ -1,17 +1,26 @@
 import streamlit as st
 from tools.add_data import register_business
+from settings.constants import (
+    BUSINESS_NEW_HEADER,
+    BUSINESS_COMPANY_NAME,
+    BUSINESS_ID_LABEL,
+    SAVE_BTN,
+    BUSINESS_ADD_SUCCESS,
+    BUSINESS_ADD_FAILURE,
+    ICON_SAVE,
+)
 
-st.header("עסק חדש")
+st.header(BUSINESS_NEW_HEADER)
 
 with st.form("add_business"):
-    company_name = st.text_input("שם חברה")
-    business_id = st.text_input("מספר ח.פ")
-    submitted = st.form_submit_button("שמור")
+    company_name = st.text_input(BUSINESS_COMPANY_NAME)
+    business_id = st.text_input(BUSINESS_ID_LABEL)
+    submitted = st.form_submit_button(SAVE_BTN, icon=ICON_SAVE)
 
 if submitted:
     resp = register_business(company_name, business_id)
     if resp:
-        st.success("העסק נוצר")
+        st.success(BUSINESS_ADD_SUCCESS)
     else:
-        st.error("נכשלה יצירת העסק")
+        st.error(BUSINESS_ADD_FAILURE)
         st.stop()

--- a/ui/category_mng.py
+++ b/ui/category_mng.py
@@ -1,8 +1,9 @@
 import streamlit as st
 from tools.api import get, post
 from tools.fetch_data import fetch_categories
+from settings.constants import NAV_CATEGORIES
 
-st.header("קטגוריות")
+st.header(NAV_CATEGORIES)
 
 
 # List categories

--- a/ui/category_new.py
+++ b/ui/category_new.py
@@ -1,19 +1,28 @@
 import streamlit as st
 from tools.api import post
+from settings.constants import (
+    CATEGORY_NEW_HEADER,
+    CATEGORY_NAME_LABEL,
+    SAVE_BTN,
+    CATEGORY_ADD_SUCCESS,
+    CATEGORY_ADD_EXISTS,
+    CATEGORY_ADD_FAILURE,
+    ICON_SAVE,
+)
 
-st.header("קטגוריה חדשה")
+st.header(CATEGORY_NEW_HEADER)
 
 # Add category
 with st.form("add_category"):
-    name = st.text_input("שם קטגוריה")
-    submitted = st.form_submit_button("שמור")
+    name = st.text_input(CATEGORY_NAME_LABEL)
+    submitted = st.form_submit_button(SAVE_BTN, icon=ICON_SAVE)
 if submitted:
     resp = post("/categories", json={"category_name": name})
     if resp.ok:
-        st.success("הקטגוריה נוספה")
+        st.success(CATEGORY_ADD_SUCCESS)
     elif resp.status_code == 409:
-        st.warning("הקטגוריה כבר קיימת")
+        st.warning(CATEGORY_ADD_EXISTS)
     else:
-        st.error("נכשלה הוספת הקטגוריה")
+        st.error(CATEGORY_ADD_FAILURE)
         st.stop()
 

--- a/ui/offer_new.py
+++ b/ui/offer_new.py
@@ -8,6 +8,7 @@ from settings.constants import (
     OFFER_SUBMIT_BTN,
     OFFER_SUBMIT_SUCCESS,
     OFFER_SUBMIT_ERROR,
+    ICON_SEND,
 )
 from tools.fetch_data import fetch_projects, fetch_categories, fetch_tasks
 
@@ -67,7 +68,7 @@ with st.container(border=True):
     st.markdown(f"### סה\"כ הצעת מחיר: ₪{total_sum:,.2f}")
 
     # Submit form
-    submitted = st.button(OFFER_SUBMIT_BTN)
+    submitted = st.button(OFFER_SUBMIT_BTN, icon=ICON_SEND)
     prices = st.session_state.prices
 
 if submitted:

--- a/ui/project_mng.py
+++ b/ui/project_mng.py
@@ -1,10 +1,19 @@
 import streamlit as st
 from tools.helpers import business_category_selection
-from settings.constants import SELECT_PROJECT
+from settings.constants import (
+    NAV_PROJECTS,
+    SELECT_PROJECT,
+    PROJECT_FILES_BTN,
+    PROJECT_DELETE_BTN,
+    PROJECT_ASSIGN_BUSINESS_BTN,
+    ICON_FILES,
+    ICON_DELETE,
+    ICON_ASSIGN,
+)
 from tools.fetch_data import fetch_projects
 from tools.helpers import project_del, project_files
 
-st.header("פרויקטים")
+st.header(NAV_PROJECTS)
 
 with st.container(border=True):
     projects = fetch_projects()
@@ -13,12 +22,12 @@ with st.container(border=True):
         project_id = projects.get(project_name)
         c1, c2 = st.columns(2)
         with c1:
-            if st.button("קבצי פרויקט", width="stretch"):
+            if st.button(PROJECT_FILES_BTN, icon=ICON_FILES, width="stretch"):
                 project_files(project_id)
         with c2:
-            if st.button("מחיקה", width="stretch"):
+            if st.button(PROJECT_DELETE_BTN, icon=ICON_DELETE, width="stretch"):
                 project_del(project_id)
-        if st.button(label="הקצאת קבלני משנה לפריוקט", width="stretch", type="primary"):
+        if st.button(PROJECT_ASSIGN_BUSINESS_BTN, width="stretch", type="primary", icon=ICON_ASSIGN):
             business_category_selection(project_id)
 
 

--- a/ui/project_new.py
+++ b/ui/project_new.py
@@ -1,12 +1,25 @@
 import streamlit as st
 from tools.api import post
-from settings.constants import FIELD_LABELS, PROJECT_REQUIRED_FORM_KEYS, PROJECT_SKN_PROCESS_TEXT, \
-    PROJECT_CREATION_SUCCESS_TEXT, PROJECT_SKN_UPLOAD_SUCCESS_TEXT, PROJECT_SKN_PROCESS_SUCCESS_TEXT, \
-    PROJECT_SKN_PROCESS_FAILURE_TEXT, PROJECT_SKN_UPLOAD_FAILURE_TEXT, PROJECT_FILE_TYPE_SKN, \
-    PROJECT_CREATION_FAILURE_TEXT, PROJECT_OTHER_UPLOAD_SUCCESS_TEXT, PROJECT_OTHER_UPLOAD_FAILURE_TEXT, ICON_PROJECTS
+from settings.constants import (
+    FIELD_LABELS,
+    PROJECT_REQUIRED_FORM_KEYS,
+    PROJECT_SKN_PROCESS_TEXT,
+    PROJECT_CREATION_SUCCESS_TEXT,
+    PROJECT_SKN_UPLOAD_SUCCESS_TEXT,
+    PROJECT_SKN_PROCESS_SUCCESS_TEXT,
+    PROJECT_SKN_PROCESS_FAILURE_TEXT,
+    PROJECT_SKN_UPLOAD_FAILURE_TEXT,
+    PROJECT_FILE_TYPE_SKN,
+    PROJECT_CREATION_FAILURE_TEXT,
+    PROJECT_OTHER_UPLOAD_SUCCESS_TEXT,
+    PROJECT_OTHER_UPLOAD_FAILURE_TEXT,
+    PROJECT_NEW_HEADER,
+    SAVE_BTN,
+    ICON_SAVE,
+)
 from tools.helpers import get_label
 
-st.header("פרויקט חדש")
+st.header(PROJECT_NEW_HEADER)
 
 
 def validate_form(required_keys=None):
@@ -37,9 +50,10 @@ with st.form("add_project"):
         file_type = st.text_input(get_label('file_type'), key='file_type')
 
     submitted = st.form_submit_button(
-        "שמור",
+        SAVE_BTN,
         on_click=validate_form,
-        kwargs={'required_keys': PROJECT_REQUIRED_FORM_KEYS}
+        kwargs={'required_keys': PROJECT_REQUIRED_FORM_KEYS},
+        icon=ICON_SAVE,
     )
 
 if submitted:

--- a/ui/settings/constants.py
+++ b/ui/settings/constants.py
@@ -63,6 +63,11 @@ ICON_MANAGE = ":material/settings:"
 ICON_NEW = ":material/add:"
 ICON_REPORTS = ":material/analytics:"  # גרף עמודות
 ICON_REFRESH = ":material/refresh:"
+ICON_FILES = ":material/description:"
+ICON_DELETE = ":material/delete:"
+ICON_ASSIGN = ":material/handshake:"
+ICON_SAVE = ":material/save:"
+ICON_SEND = ":material/send:"
 
 
 FETCH_PROJECTS = "טוען פרויקטים"
@@ -76,6 +81,26 @@ SELECT_PROJECT = "בחר פרויקט"
 SELECT_CATEGORY = "בחר קטגוריה"
 SELECT_BUSINESSES = "בחר בקבלני משנה"
 
+SAVE_BTN = "שמור"
+
+PROJECT_FILES_BTN = "קבצי פרויקט"
+PROJECT_DELETE_BTN = "מחיקה"
+PROJECT_ASSIGN_BUSINESS_BTN = "הקצאת קבלני משנה לפרויקט"
+
+CATEGORY_NEW_HEADER = "קטגוריה חדשה"
+CATEGORY_NAME_LABEL = "שם קטגוריה"
+CATEGORY_ADD_SUCCESS = "הקטגוריה נוספה"
+CATEGORY_ADD_EXISTS = "הקטגוריה כבר קיימת"
+CATEGORY_ADD_FAILURE = "נכשלה הוספת הקטגוריה"
+
+BUSINESS_NEW_HEADER = "עסק חדש"
+BUSINESS_COMPANY_NAME = "שם חברה"
+BUSINESS_ID_LABEL = "מספר ח.פ"
+BUSINESS_ADD_SUCCESS = "העסק נוצר"
+BUSINESS_ADD_FAILURE = "נכשלה יצירת העסק"
+
+PROJECT_NEW_HEADER = "פרויקט חדש"
+
 FIELD_LABELS = {
     "new_project_name": "שם הפרויקט",
     "new_deadline": "תאריך היעד",
@@ -83,3 +108,4 @@ FIELD_LABELS = {
     "uploaded_other": "קובץ נוסף",
     "file_type": "סוג הקובץ"
 }
+

--- a/ui/tools/design.py
+++ b/ui/tools/design.py
@@ -63,19 +63,71 @@ def set_rtl():
         text-align: right;
       }
 
-      /* Buttons: RTL text, LTR icon */
+      /* FIXED: Regular Buttons RTL with proper alignment */
       [data-testid="stButton"] > button {
-        direction: rtl;
-        unicode-bidi: isolate-override;
-        display: inline-flex;
-        align-items: center;
-        gap: .4rem;
+        direction: rtl !important;
+        text-align: right !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        gap: 0.5rem !important;
+        flex-direction: row-reverse !important;
+        padding: 0.375rem 0.75rem !important;
+        min-height: 38px !important;
+        box-sizing: border-box !important;
       }
 
+      /* FIXED: Form Submit Buttons - specific targeting */
+      [data-testid="stFormSubmitButton"] button {
+        direction: rtl !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        flex-direction: row-reverse !important;
+        gap: 0.25rem !important;
+        padding: 0.375rem 0.75rem !important;
+      }
+
+      /* Fix Form Submit Button icon positioning */
+      [data-testid="stFormSubmitButton"] button > span[data-testid="stIconMaterial"] {
+        order: 2 !important;
+        margin-left: 0.25rem !important;
+        margin-right: 0 !important;
+        flex-shrink: 0 !important;
+      }
+
+      /* Fix Form Submit Button text positioning */
+      [data-testid="stFormSubmitButton"] button > div[data-testid="stMarkdownContainer"] {
+        order: 1 !important;
+        margin-right: 0 !important;
+        margin-left: 0 !important;
+        text-align: right !important;
+      }
+
+      /* Ensure form submit button text is properly aligned */
+      [data-testid="stFormSubmitButton"] button p {
+        margin: 0 !important;
+        text-align: right !important;
+        direction: rtl !important;
+      }
+
+      /* Handle regular button icons */
       [data-testid="stButton"] .material-icons,
-      [data-testid="stButton"] [class^="material-icons"] {
+      [data-testid="stButton"] [class^="material-icons"],
+      [data-testid="stButton"] svg {
         direction: ltr !important;
         unicode-bidi: isolate !important;
+        flex-shrink: 0 !important;
+        margin: 0 !important;
+      }
+
+      /* Handle regular button text */
+      [data-testid="stButton"] > button span,
+      [data-testid="stButton"] > button p {
+        margin: 0 !important;
+        padding: 0 !important;
+        line-height: 1.2 !important;
+        white-space: nowrap !important;
       }
 
       /* Expander spacing fix - target the actual HTML structure */

--- a/ui/tools/helpers.py
+++ b/ui/tools/helpers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import pandas as pd
 import streamlit as st
 
-from settings.constants import FIELD_LABELS, SELECT_BUSINESSES
+from settings.constants import FIELD_LABELS, SELECT_BUSINESSES, ICON_SEND
 from tools.fetch_data import fetch_business, fetch_categories, fetch_business_category
 from tools.add_data import register_business_category_selection, register_business_category
 
@@ -49,7 +49,7 @@ def business_category_selection(project_id: str):
 
             st.divider()
 
-        submitted = st.form_submit_button("הפצת מכרז", width="stretch", type="primary")
+        submitted = st.form_submit_button("הפצת מכרז", width="stretch", type="primary", icon=ICON_SEND)
 
     if submitted:
         business_category_items = []


### PR DESCRIPTION
## Summary
- centralize button labels and page headers in `settings/constants`
- add material icons to project management and form buttons for a cleaner UI
- use shared constants across category, business, project, and offer screens

## Testing
- `pytest`
- `python -m py_compile ui/business_new.py ui/category_mng.py ui/category_new.py ui/offer_new.py ui/project_mng.py ui/project_new.py ui/settings/constants.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbecc632dc8320a6e8a6882856c54d